### PR TITLE
chore: rename ronin-document to ronin-documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/improve-existing-content.yaml
+++ b/.github/ISSUE_TEMPLATE/improve-existing-content.yaml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         * Before submitting an issue, read the [Contribution guide](https://docs.roninchain.com/docs/community/contribute/guide).
-        * Check if someone hasn't already opened a similar [issue](https://github.com/axieinfinity/ronin-document/issues).
+        * Check if someone hasn't already opened a similar [issue](https://github.com/axieinfinity/ronin-documentation/issues).
 
   - type: checkboxes
     id: terms
@@ -15,7 +15,7 @@ body:
       label: Code of Conduct
       description: This project has a Code of Conduct that all contributors are expected to follow.
       options:
-        - label: I've read and agree to the Ronin documentation project's [Code of Conduct](https://github.com/axieinfinity/ronin-document/blob/main/CODE_OF_CONDUCT.md)
+        - label: I've read and agree to the Ronin documentation project's [Code of Conduct](https://github.com/axieinfinity/ronin-documentation/blob/main/CODE_OF_CONDUCT.md)
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/improve-site.yaml
+++ b/.github/ISSUE_TEMPLATE/improve-site.yaml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         * Before submitting an issue, read the [Contribution guide](https://docs.roninchain.com/docs/community/contribute/guide).
-        * Check if someone hasn't already opened a similar [issue](https://github.com/axieinfinity/ronin-document/issues).
+        * Check if someone hasn't already opened a similar [issue](https://github.com/axieinfinity/ronin-documentation/issues).
 
   - type: checkboxes
     id: terms
@@ -15,7 +15,7 @@ body:
       label: Code of Conduct
       description: This project has a Code of Conduct that all contributors are expected to follow.
       options:
-        - label: I've read and agree to the Ronin documentation project's [Code of Conduct](https://github.com/axieinfinity/ronin-document/blob/main/CODE_OF_CONDUCT.md)
+        - label: I've read and agree to the Ronin documentation project's [Code of Conduct](https://github.com/axieinfinity/ronin-documentation/blob/main/CODE_OF_CONDUCT.md)
           required: true
 
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Thank you for contributing to the Ronin documentation! You must fill out the inf
 Closes:
 
 <!-- If there's an existing issue for your change, link to it above.
-If there's no existing issue, create one first to make it more likely that this update is accepted: https://github.com/axieinfinity/ronin-document/issues/new/choose. -->
+If there's no existing issue, create one first to make it more likely that this update is accepted: https://github.com/axieinfinity/ronin-documentation/issues/new/choose. -->
 
 ### What's being changed
 
@@ -16,4 +16,4 @@ If there's no existing issue, create one first to make it more likely that this 
 ### Checklist
 
 - [ ] I've reviewed my changes in a preview environment (click the link in the "Preview" column to view your latest changes).
-- [ ] For content changes, I've completed the [self-review checklist](https://github.com/axieinfinity/ronin-document/blob/main/docs/CONTRIBUTING.md#self-review-checklist).
+- [ ] For content changes, I've completed the [self-review checklist](https://github.com/axieinfinity/ronin-documentation/blob/main/docs/CONTRIBUTING.md#self-review-checklist).

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Install the dependencies:
 ### Steps
 
 1. Clone this repository to create its copy on your local computer.
-2. Navigate to the `ronin-document` directory:
+2. Navigate to the `ronin-documentation` directory:
 
    ```
-   cd ronin-document
+   cd ronin-documentation
    ```
 
 3. Install the project:
@@ -47,7 +47,7 @@ By default, a browser window opens at [http://localhost:3000](http://localhost:3
 ## Contribute
 
 For instructions on how to get started with our project, see the
-[Contribution guide](https://github.com/axieinfinity/ronin-document/blob/main/docs/CONTRIBUTING.md).
+[Contribution guide](https://github.com/axieinfinity/ronin-documentation/blob/main/docs/CONTRIBUTING.md).
 
 ## Deploy
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,7 +15,7 @@ This guide gives an overview of the contribution workflow, provides guidelines o
 ## Before contributing
 
 Before you contribute, take a few minutes to review this contribution guide and
-our [Code of Conduct](https://github.com/axieinfinity/ronin-document/blob/main/CODE_OF_CONDUCT.md). This guide is intended to make the
+our [Code of Conduct](https://github.com/axieinfinity/ronin-documentation/blob/main/CODE_OF_CONDUCT.md). This guide is intended to make the
 contribution process easy and effective for everyone involved in looking at your
 issue, assessing changes, and reviewing and merging your pull request.
 
@@ -56,13 +56,13 @@ Refer to the following sections for step-by-step guidance.
 ### File an issue
 
 If you notice a problem with the documentation, check our
-[existing issues](https://github.com/axieinfinity/ronin-document/issues).
+[existing issues](https://github.com/axieinfinity/ronin-documentation/issues).
 If a related issue doesn't exist, you can open a new issue
 by clicking **New issue**.
 
 ### Resolve an issue
 
-Look through the [existing issues](https://github.com/axieinfinity/ronin-document/issues)
+Look through the [existing issues](https://github.com/axieinfinity/ronin-documentation/issues)
 to find one you'd like to solve.
 
 ### Make changes via UI
@@ -741,9 +741,9 @@ recommended to resolve but they're not mandatory.
 
 You can add new approved or rejected spelling rules to the vocabulary used by
 Vale. To add a new approved rule, add the word to
-[utils/vale/styles/Vocab/Ronin/accept.txt](https://github.com/axieinfinity/ronin-document/blob/main/.github/utils/vale/styles/Vocab/Ronin/accept.txt).
+[utils/vale/styles/Vocab/Ronin/accept.txt](https://github.com/axieinfinity/ronin-documentation/blob/main/.github/utils/vale/styles/Vocab/Ronin/accept.txt).
 For a rejected rule, add the word to
-[utils/vale/styles/Vocab/Ronin/reject.txt](https://github.com/axieinfinity/ronin-document/blob/main/.github/utils/vale/styles/Vocab/Ronin/reject.txt).
+[utils/vale/styles/Vocab/Ronin/reject.txt](https://github.com/axieinfinity/ronin-documentation/blob/main/.github/utils/vale/styles/Vocab/Ronin/reject.txt).
 The rule is case-sensitive.
 
 ### Ignore Vale inline

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,7 +18,7 @@ const config = {
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   organizationName: 'axieinfinity', // Usually your GitHub org/user name.
-  projectName: 'ronin-document', // Usually your repo name.
+  projectName: 'ronin-documentation', // Usually your repo name.
 
   staticDirectories: ['static'],
 
@@ -40,7 +40,7 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           remarkPlugins: [math],
           rehypePlugins: [katex],
-          editUrl: `https://github.com/axieinfinity/ronin-document/edit/main`,
+          editUrl: `https://github.com/axieinfinity/ronin-documentation/edit/main`,
           editLocalizedFiles: false,
           editCurrentVersion: false,
           showLastUpdateTime: true,


### PR DESCRIPTION
### Reason

Closes: #172 

### What's being changed

Links to this GitHub repo as `ronin-document` should be changed to `ronin-documentation`.

### Checklist

- [x] I've reviewed my changes in a preview environment (click the link in the "Preview" column to view your latest changes).
- [x] For content changes, I've completed the [self-review checklist](https://github.com/axieinfinity/ronin-document/blob/main/docs/CONTRIBUTING.md#self-review-checklist).
