### PR TITLE
chore: made link text consistent throughout Node operators section

### DIFF
--- a/docs/community/join.md
+++ b/docs/community/join.md
@@ -6,11 +6,13 @@ title: Join
 import DocCardList from '@theme/DocCardList'; 
 import {findSidebarItem} from '@site/src/sidebarUtils';
 
-# Social media
+## Social media
+
 Stay informed on the latest Ronin news, events, and programs:
 
 * [Discord](https://discord.gg/roninnetwork)
 * [Twitter](https://twitter.com/ronin_network)
 
-# Newsletter
-Sign up to [Ronin's Newsletter](https://roninblockchain.substack.com/)
+## Newsletter
+
+Sign up to [Ronin Newsletter](https://roninblockchain.substack.com/)

--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -7,7 +7,7 @@ import {findSidebarItem} from '@site/src/sidebarUtils';
 
 # Get started
 
-### Learn about Ronin
+## Learn about Ronin
 These guides provide general overview of Ronin and
 introduce basic concepts to get you started.
 
@@ -21,7 +21,7 @@ introduce basic concepts to get you started.
     findSidebarItem('/docs/basics/roles'),
     ]} />
 
-### Stake and delegate
+## Stake and delegate
 Learn how to use your RON tokens, where to purchase RON, 
 how to delegate your stake and transfer it between validators.
 
@@ -35,7 +35,7 @@ how to delegate your stake and transfer it between validators.
     findSidebarItem('/docs/delegators/faq'),
     ]} />
 
-### Join as a validator 
+## Join as a validator 
 These guides describe how to become a validator, change commission,
 claim rewards, manage stake, and maintain the validator's profile.
 
@@ -49,7 +49,7 @@ claim rewards, manage stake, and maintain the validator's profile.
     findSidebarItem('/docs/validators/faq'),
     ]} />
 
-### Install your Ronin node 
+## Install your Ronin node 
 This section walks you through the setup and configuration of
 Ronin nodes (validator, non-validator, archive)
 and a bridge operator node.
@@ -63,15 +63,15 @@ Start with the introduction guides, and continue from there:
     findSidebarItem('/docs/node-operators/testnet'),
     ]} />
 
-### Build on Ronin
+## Build on Ronin
 Looking to build and deploy your project on Ronin? The developer
 documentation is available on the Sky Mavis Developer Portal:
 [https://docs.skymavis.com](https://docs.skymavis.com/docs/getting-started).
 
-### Get involved
+## Get involved
 Stay informed on the latest Ronin news, events, and programs:
 
 * [Discord](https://discord.gg/P5GgF7SK)
 * [Twitter](https://twitter.com/ronin_network)
 
-Sign up to [Ronin's Newsletter](https://roninblockchain.substack.com/).
+Sign up to [Ronin Newsletter](https://roninblockchain.substack.com/).

--- a/docs/node-operators/index.mdx
+++ b/docs/node-operators/index.mdx
@@ -2,13 +2,13 @@ import DocCardList from '@theme/DocCardList';
 import {findSidebarItem} from '@site/src/sidebarUtils';
 
 # Node operators
-### Introduction
+## Introduction
 
 <DocCardList items={[
     findSidebarItem('/docs/node-operators/introduction'),
     ]} />
 
-### Setup
+## Setup
 
 <DocCardList items={[
     findSidebarItem('/docs/node-operators/setup/introduction'),
@@ -22,7 +22,7 @@ import {findSidebarItem} from '@site/src/sidebarUtils';
     findSidebarItem('/docs/node-operators/setup/cli'),
     ]} />
 
-### Resources
+## Resources
 
 <DocCardList items={[
     findSidebarItem('/docs/node-operators/resources/parameters/mainnet'),
@@ -31,7 +31,7 @@ import {findSidebarItem} from '@site/src/sidebarUtils';
     findSidebarItem('/docs/node-operators/resources/faq'),
     ]} />
 
-### Saigon testnet guides
+## Saigon testnet guides
 
 <DocCardList items={[
     findSidebarItem('/docs/node-operators/testnet/combined'),

--- a/docs/node-operators/resources/faq.md
+++ b/docs/node-operators/resources/faq.md
@@ -22,7 +22,8 @@ Verify that the account address in the response matches your registered consensu
 node       | Using account acf8bf98d1632e602d0b1761771049af21dd6597
 ```
 
-Also check the node's availability on https://stats.roninchain.com/.
+Also, check the node's availability on
+[Ronin Network Status](https://stats.roninchain.com/).
 
 ### 2. How do I know if my bridge operator node is working? {#2}
 
@@ -32,14 +33,17 @@ After starting the bridge, run the following command:
 docker-compose logs bridge | head -n 20
 ```
 
-Verify that the operator account address in the response matches your registered bridge operator address. If you're a Governing Validator, also check that the voter account address matches the registered bridge voter address.
+Verify that the operator account address in the response matches your registered
+bridge operator address. If you're a Governing Validator, also check that the
+voter account address matches the registered bridge voter address.
 
 ```
 bridge     | INFO [03-22|07:59:10.368] [RoninListener] Operator account         address=0x2e82D2b56f858f79DeeF11B160bFC4631873da2B
 bridge     | INFO [03-22|07:59:10.368] [RoninListener] Voter account            address=0x2295EdAA6BD5c07fB3227628c62Af12248106667
 ```
 
-Also check the node's availability on https://stats.roninchain.com/.
+Also, check the node's availability on
+[Ronin Network Status](https://stats.roninchain.com/).
 
 ### 3. How do I generate the required private keys? {#3}
 
@@ -53,7 +57,11 @@ We recommend using different governor and admin addresses to reduce the impact o
 
 Using a multi-signature wallet can provide an additional layer of security when running your validator node.
 
-Ronin's Validator Portal is supported in [Ronin Multisig](https://multisig.roninchain.com)—you can find it under the Multisig's **Apps** tab. After creating a safe, use your safe's address as an admin or governor address. Each action with this safe's address requires multiple confirmations depending on your safe's settings.
+The Validator Dashboard is supported in [Ronin Safe](https://multisig.roninchain.com)—
+you can find it under the **Apps** tab.
+After creating a safe, use your safe's address as an admin or governor address.
+Each action with this safe's address requires multiple confirmations depending
+on your safe's settings.
 
 <img src={multisig} width={1280} />
 
@@ -61,23 +69,37 @@ Ronin's Validator Portal is supported in [Ronin Multisig](https://multisig.ronin
 
 Consider the following:
 
-* Integrate with https://stats.roninchain.com/ for the overall status of the chain's node.
-* For each node, the system publishes metrics on port `6060` for Prometheus collection. Integrate a Prometheus-Grafana stack for more granular monitoring of your node's health.
+* Integrate with the [Ronin Network Status](https://stats.roninchain.com/) page
+  for the overall status of the chain's node.
+* For each node, the system publishes metrics on port `6060` for Prometheus
+  collection. Integrate a Prometheus-Grafana stack for more granular monitoring
+  of your node's health.
 
 ### 7. What ports (if any) have to be open to the outside world? {#7}
 
 Keep public ports only for peering and discovery, otherwise keep it internal. Our `docker-compose` configuration already binds RPC port `8545` to `localhost`.
 
-To harden your node, see [Security hardening](./../resources/security.md).
+To implement additional security measures for your node, see
+[Security hardening](./../resources/security.md).
 
 ### 8. If there is a node or bridge upgrade, how do I get this information? {#8}
 
-Latest version of Ronin and its changelog are always available at [Ronin release](https://github.com/axieinfinity/ronin/releases). A good way to keep track of upgrades is to join our [Discord](https://discord.gg/roninnetwork).
+Latest version of Ronin and its changelog are always available on
+[GitHub](https://github.com/axieinfinity/ronin/releases). A good way to keep
+track of upgrades is to join our [Discord](https://discord.gg/roninnetwork).
 
-To upgrade your node, see [Latest version](./../setup/latest.md).
+To upgrade your node, see [Latest versions](./../setup/latest.md).
 
 ### 9. How much time do I have to upgrade my nodes? {#9}
 
-Upgrades are usually backwards-compatible. It can contain performance improvements, bug fixes or new features. It's recommended that every node is upgraded as soon as possible.
+Upgrades are usually backwards-compatible. It can contain performance
+improvements, bug fixes or new features. It's recommended that every node is
+upgraded as soon as possible.
 
-An upgrade, however, can also be a hardfork, which is usually not backwards-compatible. If your node fails to upgrade before a hardfork block occurs, the data on your node can differ from that on the network. Therefore, it's critical to upgrade your node before a hardfork occurs. All Ronin-planned hardforks are announced seven days in advance on our [Discord](https://discord.gg/roninnetwork) and [Ronin Substack](https://roninblockchain.substack.com/).
+An upgrade, however, can also be a hardfork, which is usually not
+backwards-compatible. If your node fails to upgrade before a hardfork block
+occurs, the data on your node can differ from that on the network. Therefore,
+it's critical to upgrade your node before a hardfork occurs. All Ronin-planned
+hardforks are announced seven days in advance on our
+[Discord](https://discord.gg/roninnetwork) and
+[Ronin Newsletter](https://roninblockchain.substack.com/).

--- a/docs/node-operators/resources/parameters/mainnet.md
+++ b/docs/node-operators/resources/parameters/mainnet.md
@@ -11,8 +11,8 @@ tags:
 * Chain ID (network ID): `2020`
 * RPC endpoint: [https://api.roninchain.com/rpc](https://api.roninchain.com/rpc)
 * Consensus: DPoS (Consortium)
-* Stats: [https://stats.roninchain.com](https://stats.roninchain.com)
-* Explorer: [https://app.roninchain.com](https://app.roninchain.com)
+* Network status: [stats.roninchain.com](https://stats.roninchain.com)
+* Explorer: [app.roninchain.com](https://app.roninchain.com)
 * Genesis file: [mainnet.json](https://github.com/axieinfinity/ronin/blob/master/genesis/mainnet.json)
 * Block time: minimum 3 seconds
 * Gas price: 20 gwei
@@ -23,7 +23,7 @@ tags:
 * Governing Validators: 12
 * Standard Validators: 10
 
-For today's validator set, see [https://app.roninchain.com/staking](https://app.roninchain.com/staking?tab=validator).
+For today's validator set, visit [RON Staking](https://app.roninchain.com/staking?tab=validator).
 
 ## Genesis contracts
 

--- a/docs/node-operators/resources/parameters/testnet.md
+++ b/docs/node-operators/resources/parameters/testnet.md
@@ -11,8 +11,8 @@ tags:
 * Chain ID (network ID): `2021`
 * RPC endpoint: [https://saigon-testnet.roninchain.com/rpc](https://saigon-testnet.roninchain.com/rpc)
 * Consensus: DPoS (Consortium)
-* Stats: [https://saigon-stats.roninchain.com/](https://saigon-stats.roninchain.com/)
-* Explorer: [https://saigon-app.roninchain.com](https://saigon-app.roninchain.com)
+* Network status: [saigon-stats.roninchain.com](https://saigon-stats.roninchain.com/)
+* Explorer: [saigon-app.roninchain.com](https://saigon-app.roninchain.com)
 * Genesis file: [testnet.json](https://github.com/axieinfinity/ronin/blob/master/genesis/testnet.json)
 
 ## Validator set
@@ -21,7 +21,7 @@ tags:
 * Governing Validators: 11
 * Standard Validators: 10
 
-For today's validator set, see [https://saigon-app.roninchain.com/staking](https://saigon-app.roninchain.com/staking?tab=validator).
+For today's validator set, see [RON Staking](https://saigon-app.roninchain.com/staking?tab=validator).
 
 ## Contracts
 

--- a/docs/node-operators/setup/cli.md
+++ b/docs/node-operators/setup/cli.md
@@ -8,14 +8,14 @@ tags:
 
 This guide demonstrates how to build a Ronin CLI (command-line tool) and compile the node binary on your own instead of using a packed binary from Docker. With the CLI tool, you can install the Ronin node and configure it as a non-validator node (default), validator node, or archive node.
 
-### Prerequisites
+## Prerequisites
 
 To build the Ronin CLI, you need to install the following dependencies:
 
 * Golang 1.17 or later (follow the instructions at [https://go.dev/doc/install](https://go.dev/doc/install))
 * C compiler
 
-### 1. Build locally
+## 1. Build locally
 
 1. Clone the Ronin repository:
 
@@ -43,7 +43,7 @@ To build the Ronin CLI, you need to install the following dependencies:
   cp ./build/bin/ronin /usr/local/bin
   ```
 
-### 2. Initialize the genesis block
+## 2. Initialize the genesis block
 
 Before running a node, you need to initialize the genesis block to set up the origin state of the chain. The genesis files are located in the repository's `genesis` directory, and include the path where you store the node's data—for example, `/ronin/data`.
 
@@ -51,7 +51,7 @@ Before running a node, you need to initialize the genesis block to set up the or
   ronin init genesis/mainnet.json --datadir /ronin/data
   ```
 
-### 3. Start the node
+## 3. Start the node
 
 Run the following command to start a full (non-validator) Ronin node on the mainnet:
 
@@ -64,9 +64,9 @@ Run the following command to start a full (non-validator) Ronin node on the main
   --ws --ws.addr 0.0.0.0 --ws.port 8546 --ws.origins '*'
   ```
 
-### Command reference
+## Command reference
 
-#### Synopsis
+### Synopsis
 
 ```
 ronin [options] [command] [command options] [arguments...]
@@ -74,7 +74,7 @@ ronin [options] [command] [command options] [arguments...]
 
 Use `ronin [command] help` for information on a specific command.
 
-#### Available commands
+### Available commands
 
 ```   
 account                            Manage accounts
@@ -102,7 +102,7 @@ wallet                             Manage Ethereum presale wallets
 help, h                            Shows a list of commands or help for one command
 ```
 
-#### Ethereum options
+### Ethereum options
 
 ```
   --config value                      TOML configuration file
@@ -128,7 +128,7 @@ help, h                            Shows a list of commands or help for one comm
   --whitelist value                   Comma-separated block number-to-hash mappings to enforce (<number>=<hash>)
 ```
   
-#### Light client options
+### Light client options
 
 ```
 --light.serve value                 Maximum percentage of time allowed for serving LES requests (multi-threaded processing allows values over 100) (default: 0)
@@ -142,7 +142,7 @@ help, h                            Shows a list of commands or help for one comm
 --light.nosyncserve                 Enables serving light clients before syncing
 ```
 
-#### Developer chain options
+### Developer chain options
 
 ```
 --dev                               Ephemeral proof-of-authority network with a pre-funded developer account, mining enabled
@@ -150,7 +150,7 @@ help, h                            Shows a list of commands or help for one comm
 --dev.gaslimit value                Initial block gas limit (default: 11500000)
 ```
 
-#### Ethash options
+### Ethash options
 
 ```
 --ethash.cachedir value             Directory to store the ethash verification caches (default = inside the datadir)
@@ -163,7 +163,7 @@ help, h                            Shows a list of commands or help for one comm
 --ethash.dagslockmmap               Lock memory maps for recent ethash mining DAGs
 ```
 
-#### Transaction pool options
+### Transaction pool options
 
 ```
 --txpool.locals value               Comma-separated accounts to treat as locals (no flush, priority inclusion)
@@ -179,7 +179,7 @@ help, h                            Shows a list of commands or help for one comm
 --txpool.lifetime value             Maximum amount of time non-executable transaction are queued (default: 3h0m0s)
 ```
 
-#### Performance tuning options
+### Performance tuning options
 
 ```
 --cache value                       Megabytes of memory allocated to internal caching (default = 4096 mainnet full node, 128 light mode) (default: 1024)
@@ -193,7 +193,7 @@ help, h                            Shows a list of commands or help for one comm
 --cache.preimages                   Enable recording the SHA3/keccak preimages of trie s
 ```
   
-#### Account options
+### Account options
 
 ```
 --unlock value                      Comma-separated list of accounts to unlock
@@ -202,7 +202,7 @@ help, h                            Shows a list of commands or help for one comm
 --allow-insecure-unlock             Allow insecure account unlocking when account-related RPCs are exposed by http
 ```
  
-#### API and console options
+### API and console options
 
 ```
 --ipcdisable                        Disable the IPC-RPC server
@@ -232,7 +232,7 @@ help, h                            Shows a list of commands or help for one comm
 --preload value                     Comma-separated list of JavaScript files to preload into the console
 ```
 
-#### Networking options
+### Networking options
 
 ```
 --bootnodes value                   Comma-separated enode URLs for P2P discovery bootstrap
@@ -249,7 +249,7 @@ help, h                            Shows a list of commands or help for one comm
 --nodehex value                     P2P node as hex (for testing)
 ```
 
-#### Miner options
+### Miner options
 
 ```
 --mine                              Enable mining
@@ -264,7 +264,7 @@ help, h                            Shows a list of commands or help for one comm
 --miner.noverify                    Disable remote sealing verification
 ```
 
-#### Gas price oracle options
+### Gas price oracle options
 
 ```
 --gpo.blocks value                  Number of recent blocks to check for gas prices (default: 20)
@@ -273,13 +273,13 @@ help, h                            Shows a list of commands or help for one comm
 --gpo.ignoreprice value             Gas price below which gpo will ignore transactions (default: 2)
 ```
   
-#### Virtual machine options
+### Virtual machine options
 
 ```
 --vmdebug                           Record information useful for VM and contract debugging
 ```
 
-#### Logging and debugging options
+### Logging and debugging options
 
 ```
 --fakepow                           Disables proof-of-work verification
@@ -298,7 +298,7 @@ help, h                            Shows a list of commands or help for one comm
 --trace value                       Write execution trace to the given file
 ```
 
-#### Metrics and stats options
+### Metrics and stats options
 
 ```
 --metrics                              Enable metrics collection and reporting
@@ -317,13 +317,13 @@ help, h                            Shows a list of commands or help for one comm
 --metrics.influxdb.organization value  InfluxDB organization name (v2 only) (default: "geth")
 ```
   
-#### Aliased (deprecated) options
+### Aliased (deprecated) options
 
 ```
 --nousb                             Disables monitoring for and managing USB hardware wallets (deprecated)
 ```
 
-#### Miscellaneous options
+### Miscellaneous options
 
 ```
 --snapshot                          Enables snapshot-database mode (default = enable)

--- a/docs/node-operators/setup/generate-keys.md
+++ b/docs/node-operators/setup/generate-keys.md
@@ -9,11 +9,13 @@ import mobile from './assets/mobile.png';
 
 This guide demonstrates how to generate private keys for your nodes.
 
-## Generate private keys locally
+## Generate locally
 
 ### Prerequisites
 
-[Go](https://go.dev/doc/install) (version 1.17 or later)
+Go (version 1.17 or later). Follow the
+[installation instructions](https://go.dev/doc/install)
+on the official website.
 
 ### Steps
 
@@ -41,9 +43,11 @@ following commands:
     ./ethkey inspect --private your-key-name
     ```
 
-## Generate private keys using Ronin Wallet
+## Generate using Ronin Wallet
 
-You can generate private keys using the Ronin Wallet—both the browser extension and the mobile app, which be downloaded on the [Ronin Wallet](https://wallet.roninchain.com/) page. Refer to the flow guides to learn how to generate your keys.
+You can generate private keys using Ronin Wallet—both the browser extension and the mobile app, which can be downloaded on the [Ronin Wallet](https://wallet.roninchain.com/) page. 
+
+Follow the steps in the flow guides to generate your keys using Ronin Wallet.
 
 ### Browser extension
 

--- a/docs/node-operators/setup/latest.md
+++ b/docs/node-operators/setup/latest.md
@@ -8,16 +8,17 @@ This page describes how to get the latest version of the node's software.
 
 ## Ronin node
 
-Every Ronin node release is published on GitHub:
-[https://github.com/axieinfinity/ronin/releases](https://github.com/axieinfinity/ronin/releases).
-To find the Docker image for each release, visit the links in the sections that follow.
+Every Ronin node release is published on
+[GitHub](https://github.com/axieinfinity/ronin/releases).
 
 ### Mainnet
 
-* Docker Hub: [https://hub.docker.com/r/axieinfinity/ronin-mainnet/tags](https://hub.docker.com/r/axieinfinity/ronin-mainnet/tags)
-* GitHub Container Registry: [https://github.com/axieinfinity/ronin/pkgs/container/ronin](https://github.com/axieinfinity/ronin/pkgs/container/ronin)
+To find the Docker image for each mainnet release, visit the following:
 
-To download the latest image, follow these steps:
+* [Docker Hub](https://hub.docker.com/r/axieinfinity/ronin-mainnet/tags)
+* [GitHub Container Registry](https://github.com/axieinfinity/ronin/pkgs/container/ronin)
+
+To download the latest image for your node, follow these steps:
 
 1. In the `.env` file, set `NODE_IMAGE` to the following:
 
@@ -30,9 +31,10 @@ To download the latest image, follow these steps:
 
 ### Saigon testnet
 
-To find the Docker image for each release, visit Docker Hub: [https://hub.docker.com/r/axieinfinity/ronin-testnet/tags](https://hub.docker.com/r/axieinfinity/ronin-testnet/tags).
+To find the Docker image for each testnet release, visit
+[Docker Hub](https://hub.docker.com/r/axieinfinity/ronin-testnet/tags).
 
-To download the latest image, follow these steps:
+To download the latest image for your node, follow these steps:
 
 1. In the `.env` file, set `NODE_IMAGE` to the following:
 
@@ -45,10 +47,10 @@ To download the latest image, follow these steps:
 
 ## Bridge operator
 
-Every bridge release is published on GitHub:
-[https://github.com/axieinfinity/bridge-v2/releases](https://github.com/axieinfinity/bridge-v2/releases).
-To find the Docker image for each release, visit Docker Hub:
-[https://hub.docker.com/r/axieinfinity/bridge/tags](https://hub.docker.com/r/axieinfinity/bridge/tags).
+Every bridge release is published on
+[GitHub](https://github.com/axieinfinity/bridge-v2/releases). To find the Docker
+image for each release, visit
+[Docker Hub](https://hub.docker.com/r/axieinfinity/bridge/tags).
 
 To download the latest image, follow these steps:
 

--- a/docs/node-operators/setup/mainnet/archive.md
+++ b/docs/node-operators/setup/mainnet/archive.md
@@ -130,4 +130,4 @@ The size of your Ronin node will also grow over time.
 
   This command pulls a Ronin node image and starts the service you defined.
 
-7. After a few minutes, go to the [stats page](https://stats.roninchain.com/) to check the status of the node. If it's green, the node is connected and up to date with the network.
+7. After a few minutes, check the status of your node on the [Ronin Network Status](https://stats.roninchain.com/) page. If it's green, the node is connected and up to date with the network.

--- a/docs/node-operators/setup/mainnet/bridge.md
+++ b/docs/node-operators/setup/mainnet/bridge.md
@@ -219,7 +219,7 @@ The size of your Ronin node will also grow over time.
 
   This command pulls a Ronin node image, a bridge image, a Postgres database, and starts the services you defined.
 
-8. After a few minutes, go to the [stats page](https://stats.roninchain.com/) to check the status of your node. If it's green, the node is connected and up to date with the network.
+8. After a few minutes, check the status of your node on the [Ronin Network Status](https://stats.roninchain.com/) page. If it's green, the node is connected and up to date with the network.
 
 9. Review the log for the bridge and the validator node (the node should sync to the latest block for making the bridge work).
 

--- a/docs/node-operators/setup/mainnet/combined.md
+++ b/docs/node-operators/setup/mainnet/combined.md
@@ -223,7 +223,7 @@ The size of your node will also grow over time.
   
   This command pulls a Ronin node image, a bridge image, a Postgres database, and starts the services you defined.
 
-8. After a few minutes, go to the [stats page](https://stats.roninchain.com/) to check the status of your node. If it's green, the node is connected and up to date with the network.
+8. After a few minutes, check the status of your node on the [Ronin Network Status](https://stats.roninchain.com/) page. If it's green, the node is connected and up to date with the network.
 
 9. Review the log for the validator and the bridge (the node should sync to the latest block for making the bridge work).
 

--- a/docs/node-operators/setup/mainnet/non-validator.md
+++ b/docs/node-operators/setup/mainnet/non-validator.md
@@ -146,4 +146,4 @@ The size of your node will also grow over time.
   docker logs node -f --tail 100
   ```
 
-9. After a few minutes, go to the [stats page](https://stats.roninchain.com/) to check the status of your node. If it's green, the node is connected and up to date with the network.
+9. After a few minutes, check the status of your node on the [Ronin Network Status](https://stats.roninchain.com/) page. If it's green, the node is connected and up to date with the network.

--- a/docs/node-operators/setup/mainnet/validator.md
+++ b/docs/node-operators/setup/mainnet/validator.md
@@ -152,8 +152,8 @@ The size of your node will also grow over time.
   docker logs node -f --tail 100
   ```
 
-9. After a few minutes, go to the [stats page](https://stats.roninchain.com/) to check the status of your node. If it's green, the node is connected and up to date with the network.
+9. After a few minutes, check the status of your node on the [Ronin Network Status](https://stats.roninchain.com/) page. If it's green, the node is connected and up to date with the network.
 
-## What's next
+## Next step
 
 Install and run a bridge operator as described in [Run a bridge operator node](./bridge.md).

--- a/docs/node-operators/setup/testnet/archive.md
+++ b/docs/node-operators/setup/testnet/archive.md
@@ -133,4 +133,4 @@ The size of your Ronin node will also grow over time.
   
   This command pulls a Ronin node image and starts the service you defined.
 
-7. After a few minutes, go to the [stats page](https://saigon-stats.roninchain.com/) to check the status of your node. If it's green, the node is connected and up to date with the network.
+7. After a few minutes, check the status of your node on the [Ronin Network Status](https://saigon-stats.roninchain.com/) page. If it's green, the node is connected and up to date with the network.

--- a/docs/node-operators/setup/testnet/combined.md
+++ b/docs/node-operators/setup/testnet/combined.md
@@ -231,7 +231,7 @@ The size of your node will also grow over time.
   
   This command pulls a Ronin node image, a bridge image, a Postgres database, and starts the services you defined.
 
-8. After a few minutes, go to the [stats page](https://saigon-stats.roninchain.com/) to check the status of your node. If it's green, the node is connected and up to date with the network.
+8. After a few minutes, check the status of your node on the [Ronin Network Status](https://saigon-stats.roninchain.com/) page. If it's green, the node is connected and up to date with the network.
 
 9. Review the log for the validator and the bridge (the node should sync to the latest block for making the bridge work).
 

--- a/docs/node-operators/setup/testnet/non-validator.md
+++ b/docs/node-operators/setup/testnet/non-validator.md
@@ -151,4 +151,4 @@ The size of your node will also grow over time.
   docker logs node -f --tail 100
   ```
 
-9. After a few minutes, go to the [stats page](https://saigon-stats.roninchain.com/) to check the status of your node. If it's green, the node is connected and up to date with the network.
+9. After a few minutes, check the status of your node on the [Ronin Network Status](https://saigon-stats.roninchain.com/) page. If it's green, the node is connected and up to date with the network.


### PR DESCRIPTION
### Reason

Closes: #180

### What's being changed

- Link text in **Node operators**, to adhere to the style guide.
- In the standalone validator tutorial, the bottom section "What's next" is now called "Next step" to adhere to the template.
- In the top-level **Get started** page and the **Introduction** page in **Node operators**, heading level is changed from H3 to H2 so that hierarchy is preserved.

### Checklist

- [x] I've reviewed my changes in a preview environment (click the link in the "Preview" column to view your latest changes).
- [x] For content changes, I've completed the [self-review checklist](https://github.com/axieinfinity/ronin-documentation/blob/main/docs/CONTRIBUTING.md#self-review-checklist).
