### PR TITLE
Chore/footer link

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -219,14 +219,14 @@ After a PR is closed, your working branch is deleted.
 * The files in the `/docs` directory are further organized by category as
   described in the following table:
 
-| Directory              | Purpose                                                                                                        |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `/docs/basics`         | General information about Ronin.                                                                               |
-| `/docs/community`      | Ronin socials, contribution guide, and community initiatives.                                                  |
-| `/docs/delegators`     | Documentation for delegators.                                                                                  |
-| `/docs/developers`     | One page that points readers to the Ronin developer documentation published on the Sky Mavis Developer Portal. |
-| `/docs/node-operators` | Documentation for node operators.                                                                              |
-| `/docs/validators`     | Documentation for validators.                                                                                  |
+| Directory              | Purpose                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `/docs/basics`         | General information about Ronin.                                                                                    |
+| `/docs/community`      | Ronin socials, contribution guide, and community initiatives.                                                       |
+| `/docs/delegators`     | Documentation for delegators.                                                                                       |
+| `/docs/developers`     | One page that points readers to the Ronin developer documentation published on the Sky Mavis developer docs portal. |
+| `/docs/node-operators` | Documentation for node operators.                                                                                   |
+| `/docs/validators`     | Documentation for validators.                                                                                       |
 
 ### Sidebar
 

--- a/docs/developers/portal.md
+++ b/docs/developers/portal.md
@@ -5,6 +5,8 @@ description: Learn how to build on Ronin.
 import portal from './assets/portal.png';
 
 # Developers
-Looking to build and deploy your project on Ronin? The developer documentation is available on the Sky Mavis Developer Portal: [https://docs.skymavis.com](https://docs.skymavis.com/docs/getting-started)
+Looking to build and deploy your project on Ronin? The developer documentation
+is available on the
+[Sky Mavis developer documentaton site](https://docs.skymavis.com/docs/getting-started).
 
 <img src={portal} width={1400} />

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -174,7 +174,7 @@ const config = {
                 href: 'https://validator.roninchain.com/',
               },
               {
-                label: 'Sky Mavis Developer Portal',
+                label: 'Ronin developer documentation',
                 href: 'http://docs.skymavis.com/docs/getting-started',
               },
             ],


### PR DESCRIPTION
### Reason

Closes: #182 

### What's being changed

The text of the links to the Ronin developer documentation is being changed from "Developer Portal" to "Sky Mavis developer documentation".

### Checklist

- [x] I've reviewed my changes in a preview environment (click the link in the "Preview" column to view your latest changes).
- [x] For content changes, I've completed the [self-review checklist](https://github.com/axieinfinity/ronin-documentation/blob/main/docs/CONTRIBUTING.md#self-review-checklist).
