### PR TITLE
fix: edit circulating supply percent

### DIFF
--- a/docs/basics/rewards.md
+++ b/docs/basics/rewards.md
@@ -58,7 +58,7 @@ Following is a sensitivity analysis of the annual percentage rate (APR) for the 
 | Year 7          | 2.76%  | 2.62%  | 2.47%  | 2.33%  |
 | Year 8          | 1.16%  | 1.10%  | 1.04%  | 0.98%  |
 
-Following is a sensitivity analysis of the annual percentage rate (APR) for the first 8 years, considering the staked supply ranging from 40% to 60%, and  the commission rate of 5%.
+Following is a sensitivity analysis of the annual percentage rate (APR) for the first 8 years, considering the staked supply ranging from 40% to 70%, and  the commission rate of 5%.
 
 | % of circulating supply staked | 40%   | 50%   | 60%   | 70%   |
 | ------------------------------ | ----- | ----- | ----- | ----- |

--- a/docs/basics/rewards.md
+++ b/docs/basics/rewards.md
@@ -60,7 +60,7 @@ Following is a sensitivity analysis of the annual percentage rate (APR) for the 
 
 Following is a sensitivity analysis of the annual percentage rate (APR) for the first 8 years, considering the staked supply ranging from 40% to 60%, and  the commission rate of 5%.
 
-| % of circulating supply staked | 40%   | 50%   | 60%   | 20%   |
+| % of circulating supply staked | 40%   | 50%   | 60%   | 70%   |
 | ------------------------------ | ----- | ----- | ----- | ----- |
 | Year 1                         | 23.99% | 19.19% | 15.99% | 16.16% |
 | Year 2                         | 15.21% | 12.17% | 10.14% | 10.25% |


### PR DESCRIPTION
### Reason

Closes: N/A

### What's being changed

Changes the circulating supply percent from 20% to 70% in the table on the **Basics > Rewards** page. Modifies the introductory sentence accordingly as well.

### Checklist

- [x] I've reviewed my changes in a preview environment (click the link in the "Preview" column to view your latest changes).
- [x] For content changes, I've completed the [self-review checklist](https://github.com/axieinfinity/ronin-documentation/blob/main/docs/CONTRIBUTING.md#self-review-checklist).
