### PR TITLE
chore: add caution to remind to initialize genesis block

### DIFF
--- a/docs/node-operators/setup/cli.md
+++ b/docs/node-operators/setup/cli.md
@@ -45,11 +45,15 @@ To build the Ronin CLI, you need to install the following dependencies:
 
 ## 2. Initialize the genesis block
 
-Before running a node, you need to initialize the genesis block to set up the origin state of the chain. The genesis files are located in the repository's `genesis` directory, and include the path where you store the node's data—for example, `/ronin/data`.
+Initialize the genesis block to set up the origin state of the chain. The genesis files are located in the repository's `genesis` directory, and include the path where you store the node's data—for example, `/ronin/data`.
 
   ```
   ronin init genesis/mainnet.json --datadir /ronin/data
   ```
+
+:::caution
+Whenever you build or upgrade a node that includes a new hardfork, you must initialize the genesis block by running this command.
+:::
 
 ## 3. Start the node
 


### PR DESCRIPTION
### Reason

Closes: N/A

### What's being changed

Adds a caution block to remind node operators to run the command to initialize the genesis block.

### Checklist

- [x] I've reviewed my changes in a preview environment (click the link in the "Preview" column to view your latest changes).
- [x] For content changes, I've completed the [self-review checklist](https://github.com/axieinfinity/ronin-documentation/blob/main/docs/CONTRIBUTING.md#self-review-checklist).
