### PR TITLE
refactor: "Become a delegator" > "Stake RON"

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -772,8 +772,8 @@ more text here...
 
 Ronin uses the [Google](https://github.com/errata-ai/google) style for the
 [Google developer documentation style guide](https://developers.google.com/style).
-The style definitions are located in the `/static/styles` directory,
-and the Vale config lives in `/.vale.ini`.
+The style definitions are located in the `./github/styles` directory,
+and the Vale config lives in `.vale.ini`.
 
 ## Self-review checklist
 
@@ -790,8 +790,7 @@ checklist:
   the style guide.
 * [ ] Ensure technical accuracy of the content. Try to test your tasks and run
   all commands by yourself.
-* [ ] Run [Vale](#run-vale) in your Markdown files to check adherence to the
-  [style guide](./community/contribute/style-guide.md).  
+* [ ] Run [Vale](#run-vale) to lint your Markdown files.
 * [ ] Spot and fix any grammar and spelling errors. Vale might not highlight
   those.
 * [ ] If there are any failing checks in your PR, such as broken links,

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -522,7 +522,7 @@ this task and the concepts that it involves.
 
 ##### Examples of how-to guides
 
-* [Become a delegator](./delegators/onboarding/become-delegator.mdx)
+* [Stake RON](./delegators/onboarding/become-delegator.mdx)
 * [Run a validator node](./validators/setup/mainnet/run-validator.md)
 * [Claim rewards](./validators/manage/claim-rewards.mdx)
 * Task topics within other pages:

--- a/docs/apps/ron-staking.md
+++ b/docs/apps/ron-staking.md
@@ -9,9 +9,9 @@ RON Staking is an app where RON holders can delegate their tokens to validators,
 
 Key features:
 
-* Stake RON to validators: RON holders can stake their tokens to any validator and earn rewards.
-* Manage your stake: RON holders can increase or withdraw their stake from a validator, or move it to a different validator.
-* Claim rewards: RON holders can claim rewards for staking their tokens.
+* [Stake RON](./../delegators/onboarding/become-delegator.mdx) to validators: RON holders can stake their tokens to any validator and earn rewards.
+* [Manage your stake](./../delegators/manage/increase-withdraw-stake.mdx): RON holders can increase or withdraw their stake from a validator, or move it to a different validator.
+* [Claim rewards](./../delegators/manage/claim-rewards.mdx): RON holders can claim rewards for staking their tokens.
 
 Link: [https://app.roninchain.com/staking](https://app.roninchain.com/staking).
 

--- a/docs/basics/key-concepts.md
+++ b/docs/basics/key-concepts.md
@@ -233,7 +233,7 @@ Staking is the process through which a Ronin user "stakes" or locks their crypto
 
 Ronin's DPoS allows users to commit their RON as votes, where voting power is proportional to the number of coins held. These votes are then used to elect a number of validators who manage the blockchain on behalf of their voters, ensuring security and consensus. The staking reward is distributed to these elected validators, who then redistribute part of the reward to the users who staked their tokens proportionally to their individual contributions.
 
-For instructions on staking on Ronin, see [Become a delegator](../delegators/onboarding/become-delegator.mdx).
+For instructions on staking on Ronin, see [Stake RON](../delegators/onboarding/become-delegator.mdx).
 
 ## T
 

--- a/docs/basics/roles.md
+++ b/docs/basics/roles.md
@@ -7,11 +7,11 @@ description: Who are delegators, validators, and bridge operators, and what they
 
 A delegator is an individual that delegates their stake to a validator and earns rewards in return. By delegating their stake, delegators can participate in the network and be rewarded without the technical expertise or resources required to run a validator node themselves.
 
-### Become a delegator
+### Stake RON
 
 In Ronin, token holders can choose validators based on various factors such as the performance of the validators and their commission rate.
 
-After choosing the validators, the RON holders can follow the steps in [Register as a delegator](./../delegators/onboarding/become-delegator.mdx).
+After choosing the validators, the RON holders can follow the steps in [Stake RON](./../delegators/onboarding/become-delegator.mdx).
 
 ## Validator
 

--- a/docs/delegators/manage/increase-withdraw-stake.mdx
+++ b/docs/delegators/manage/increase-withdraw-stake.mdx
@@ -23,7 +23,7 @@ This page demonstrates how to increase, move, or withdraw your existing stake.
 
 ## Before you start
 
-Before managing your stake, you need to [become a delegator](./../onboarding/become-delegator.mdx).
+Make sure you [staked some RON](./../onboarding/become-delegator.mdx).
 
 ## Stake more
 

--- a/docs/delegators/onboarding/become-delegator.mdx
+++ b/docs/delegators/onboarding/become-delegator.mdx
@@ -1,6 +1,6 @@
 ---
-description: Delegate your RON tokens to a validator.
-title: Register as a delegator
+description: Stake your RON tokens to a validator to earn staking rewards.
+title: Stake RON
 ---
 
 import myStaking from './assets/my-staking.png';
@@ -13,47 +13,55 @@ import validatorDetails from './assets/validator-details.png';
 
 ## Overview
 
-This guide demonstrates how to delegate your RON stake to a validator
-and how to view all your delegations. The delegation tutorial is provided in
+This guide demonstrates how to stake your RON tokens to a validator
+and how to view all your stakes. Staking is also referred to as "delegation," wherein you delegate your stake of RON to a validator to earn staking rewards. 
+
+The instruction is provided in
 two formats: [video](#video) and [text](#text).
 
 ## Before you start
 
 [Have RON tokens](./../../basics/buy-ron.mdx) in your Ronin Wallet.
 
-## Delegate RON
-### Video tutorial {#video}
+## Stake RON
 
-Learn how to stake your RON with this official Staking Tutorial.
+### Video instruction {#video}
+
+Learn how to stake your RON with this official staking tutorial.
 <div class='embed-container'><iframe src='https://www.youtube.com/embed/rCSA6edBub8' frameborder='0' allowfullscreen></iframe></div>
 
-### Text tutorial {#text}
+### Text instruction {#text}
 
 1. Go to [RON staking](https://app.roninchain.com/staking) >
 **Connect wallet**.
-<img src={stepOne} width={1440} />
+   <img src={stepOne} width={1440} />
 
 2. Switch to the **All validators** tab, then pick a validator
-you want to delegate to, and then select **Delegate**.
-<img src={stepTwo} width={1440} />
+you want to delegate your stake to, and then select **Delegate**.
+   <img src={stepTwo} width={1440} />
 
-  To learn more about a validator before making a decision,
-  open the details page by selecting the validator's name
-  from the list. For more ways to learn about a validator,
-  see [Track validators](./../manage/track-validators.mdx).
-  <img src={validatorDetails} width={1440} />
+   To learn more about a validator before making a decision,
+   open the details page by selecting the validator's name
+   from the list. For more ways to learn about a validator,
+   see [Track validators](./../manage/track-validators.mdx).
+   <img src={validatorDetails} width={1440} />
 
 3. Enter the amount manually or choose **Max** to stake all available RON,
 and then select **Delegate**. Expand the estimated annual rewards to
 reveal your estimated monthly and daily earnings.
-<img src={stepThree} width={400} />
+   <img src={stepThree} width={400} />
 
 4. Confirm the transaction.
-<img src={stepFour} width={400} />
+   <img src={stepFour} width={400} />
 
-## View your delegations
+## View your stake
 
-To view the list of validators that you delegated to,
+To view the list of validators that you staked to,
 go to [RON staking](https://app.roninchain.com/staking) > **My staking**.
 
 <img src={myStaking} width={1440} />
+
+## See also
+
+* [Claim rewards](./../manage/claim-rewards.mdx)
+* [Increase, move, or remove your stake](./../manage/increase-withdraw-stake.mdx)

--- a/sidebars.js
+++ b/sidebars.js
@@ -118,7 +118,7 @@ const sidebars = {
         id: 'delegators/index',        
       },
       items: [
-        // Become a delegator
+        // Stake RON
         'delegators/onboarding/become-delegator',
         {
           type: 'category',


### PR DESCRIPTION
### Reason

Closes: N/A

### What's being changed

- Renames the article **Become a delegator** to **Stake RON**
- Adds links to staking-related articles on the **dApps > RON Staking** page
- Attempts to replace the term "delegation" with "staking", because the latter is better known to the target audience. 

### Checklist

- [x] I've reviewed my changes in a preview environment (click the link in the "Preview" column to view your latest changes).
- [x] For content changes, I've completed the [self-review checklist](https://github.com/axieinfinity/ronin-documentation/blob/main/docs/CONTRIBUTING.md#self-review-checklist).
