### PR TITLE
chore: replace ronin: with 0x

### DIFF
--- a/docs/basics/key-concepts.md
+++ b/docs/basics/key-concepts.md
@@ -9,7 +9,7 @@ title: Glossary
 
 A blockchain address is used to send and receive funds of digital assets on a blockchain network. Every blockchain has wallet addresses in some form, and most look like a long string of letters and numbers.
 
-For example, a Ronin address looks something like this: ronin:50460c4cd74094cd591455cad457e99c4ab8be0.
+For example, a Ronin address looks something like this: `0x50460c4cd74094cd591455cad457e99c4ab8be0`.
 
 ## B
 


### PR DESCRIPTION
### Reason

Closes: N/A

### What's being changed

Replaces the `ronin:` prefix with `0x` since Ronin has moved away from using the `ronin:` prefix.

### Checklist

- [x] I've reviewed my changes in a preview environment (click the link in the "Preview" column to view your latest changes).
- [x] For content changes, I've completed the [self-review checklist](https://github.com/axieinfinity/ronin-documentation/blob/main/docs/CONTRIBUTING.md#self-review-checklist).
