### PR TITLE
feat: rename 'transfer' to 'bridge'

### DIFF
--- a/docs/apps/ronin-bridge/guides/deposit-nft.md
+++ b/docs/apps/ronin-bridge/guides/deposit-nft.md
@@ -1,5 +1,5 @@
 ---
-description: Transfer NFTs from Ethereum to Ronin using Ronin Bridge.
+description: Bridge NFTs from Ethereum to Ronin using Ronin Bridge.
 slug: /apps/ronin-bridge/deposit-nft
 title: Deposit an NFT
 toc_max_heading_level: 2
@@ -19,7 +19,7 @@ To import your Ethereum wallets, see [Importing Your MetaMask Wallet to Ronin Wa
 
 1. Open [Ronin Bridge](https://app.roninchain.com/bridge) and select the **NFTs** tab.
    ![nft-deposit-0](../assets/nft-deposit-0.png)
-2. In the **From** field, connect the Ethereum wallet that you want to transfer the NFT from. The supported wallets include MetaMask, Trust Wallet, and Coinbase.
+2. In the **From** field, connect the Ethereum wallet that you want to bridge the NFT from. The supported wallets include MetaMask, Trust Wallet, and Coinbase.
    ![nft-deposit-1](../assets/nft-deposit-1.png)
 3. In the **To** field, enter the Ronin address that you want to deposit the NFT into. You can also enter the RNS (Ronin Name Service) domain name linked to the address, such as "example.ron". Make sure to specify the *full RNS name* including the ".ron" part, so that the system can recognize the linked address.
    ![nft-deposit-2](../assets/nft-deposit-2.png)
@@ -37,11 +37,11 @@ To import your Ethereum wallets, see [Importing Your MetaMask Wallet to Ronin Wa
 
 ## Step 3. Approve the NFT
 
-To deposit an NFT, you need to grant Ronin Bridge permission to transfer it, which is also referred to as *approval*. You have two ways to do it: approve a single token or approve all tokens.
+To deposit an NFT, you need to grant Ronin Bridge permission to bridge it, which is also referred to as *approval*. You have two ways to do it: approve a single token or approve all tokens.
 
 ### Approve a single token
 
-Approving a single token means that every time you transfer an NFT, you will need to approve each token individually. So when you transfer another token in the future, you will need to approve it again.
+Approving a single token means that every time you bridge an NFT, you will need to approve each token individually. So when you bridge another token in the future, you will need to approve it again.
 
 1. With the NFT selected, click **Approve NFT**.
    ![nft-deposit-5](../assets/nft-deposit-5.png)
@@ -49,13 +49,11 @@ Approving a single token means that every time you transfer an NFT, you will nee
    ![nft-deposit-6](../assets/nft-deposit-6.png)
 3. When prompted, sign the transaction in your connected wallet.
 
-When you make another transfer in the future, you will need to approve it again.
-
 ### Approve all tokens
 
-Approving all tokens means that you only need to grant approval once, and your future NFT transfers will not require any approval.
+Approving all tokens means that you only need to grant approval once, and your future NFT bridges will not require any approval.
 
-1. Select the NFT you want to transfer, and then click **Approve NFT**.
+1. Select the NFT you want to bridge, and then click **Approve NFT**.
    ![nft-deposit-5](../assets/nft-deposit-5.png)
 2. Select **All tokens**.
    ![nft-deposit-7](../assets/nft-deposit-7.png)
@@ -65,7 +63,7 @@ You can revoke token approval by using the [Token Revoke](https://ronin.axiedao.
 
 ## Step 4. Confirm your deposit
 
-1. Review the transaction details, including the gas fees associated with the deposit. Make sure you have enough ETH in your Ethereum wallet to cover the fees. If everything looks correct, select **Deposit**.
+1. Review the transaction details, including the gas fees associated with the deposit. Make sure you have enough ETH in your Ethereum wallet to pay gas. If everything looks correct, select **Deposit**.
    ![nft-deposit-8](../assets/nft-deposit-8.png)
 2. When prompted, sign the transaction in your connected wallet.
 3. Wait for the transaction to be confirmed by the network. Be patient, however, as transactions can take some time to complete, depending on network congestion and gas fees.

--- a/docs/apps/ronin-bridge/guides/deposit-token.md
+++ b/docs/apps/ronin-bridge/guides/deposit-token.md
@@ -1,5 +1,5 @@
 ---
-description: Transfer ERC20 tokens from Ethereum to Ronin using Ronin Bridge.
+description: Bridge ERC20 tokens from Ethereum to Ronin using Ronin Bridge.
 slug: /apps/ronin-bridge/deposit-token
 title: Deposit an ERC20 token
 ---
@@ -18,7 +18,7 @@ To import your Ethereum wallets, see [Importing Your MetaMask Wallet to Ronin Wa
 
 1. Open [Ronin Bridge](https://app.roninchain.com/bridge).
    ![token-deposit-0](../assets/token-deposit-0.png)
-2. In the **From** field, connect the Ethereum wallet that you want to transfer the token from. The supported wallets include MetaMask, Trust Wallet, and Coinbase.
+2. In the **From** field, connect the Ethereum wallet that you want to bridge the token from. The supported wallets include MetaMask, Trust Wallet, and Coinbase.
    ![token-deposit-1](../assets/token-deposit-1.png)
 3. In the **To** field, enter the Ronin address that you want to deposit the token into. You can also enter the RNS (Ronin Name Service) domain name linked to the address, such as "example.ron". Make sure to specify the *full RNS name* including the ".ron" part, so that the system can recognize the linked address.
    ![token-deposit-2](../assets/token-deposit-2.png)
@@ -29,12 +29,12 @@ To import your Ethereum wallets, see [Importing Your MetaMask Wallet to Ronin Wa
 
 ## Step 2. Choose the token and amount
 
-Choose the ERC20 token that you want to deposit, then enter the amount manually or select **Max** to transfer the entire balance of this token available in your connected wallet.
+Choose the ERC20 token that you want to deposit, then enter the amount manually or select **Max** to bridge the entire balance of this token available in your connected wallet.
 ![token-deposit-3](../assets/token-deposit-3.png)
 
 ## Step 3. Confirm your deposit
 
-1. Review the transaction details, including the gas fees associated with the deposit. Make sure you have enough ETH in your Ethereum wallet to cover the fees. If everything looks correct, select **Deposit**.
+1. Review the transaction details, including the gas fees associated with the deposit. Make sure you have enough ETH in your Ethereum wallet to pay gas. If everything looks correct, select **Deposit**.
    ![token-deposit-4](../assets/token-deposit-4.png)
 2. When prompted, sign the transaction in your connected wallet.
 3. Wait for the transaction to be confirmed by the network. Be patient, however, as transactions can take some time to complete, depending on network congestion and gas fees.

--- a/docs/apps/ronin-bridge/guides/withdraw-nft.md
+++ b/docs/apps/ronin-bridge/guides/withdraw-nft.md
@@ -1,5 +1,5 @@
 ---
-description: Transfer NFTs from Ronin to Ethereum using Ronin Bridge.
+description: Bridge NFTs from Ronin to Ethereum using Ronin Bridge.
 slug: /apps/ronin-bridge/withdraw-nft
 title: Withdraw an NFT
 toc_max_heading_level: 2
@@ -11,7 +11,7 @@ This guide describes how to use Ronin Bridge to send an NFT (non-fungible token)
 
 ## Prerequisites
 
-If you access Ronin Bridge through the Ronin Wallet mobile app, then you can only connect Ethereum wallets imported into your Ronin Wallet beforehand. 
+If you access Ronin Bridge through the Ronin Wallet mobile app, then you can only connect Ethereum wallets imported into your Ronin Wallet beforehand.
 
 To import your Ethereum wallets, see [Importing Your MetaMask Wallet to Ronin Wallet](https://support.roninchain.com/hc/en-us/articles/14862812718107-Importing-Your-MetaMask-Wallet-to-Ronin-Wallet).
 
@@ -23,9 +23,9 @@ To import your Ethereum wallets, see [Importing Your MetaMask Wallet to Ronin Wa
    ![nft-withdrawal-1](../assets/nft-withdrawal-1.png)
 3. In the **From** field, connect your Ronin Wallet using the browser extension or mobile app.
    ![nft-withdrawal-2](../assets/nft-withdrawal-2.png)
-4. In the **To** field, enter the Ethereum address that you want to transfer the NFT to. Double-check the recipient address to avoid sending your NFT to the wrong destination.
+4. In the **To** field, enter the Ethereum address that you want to bridge the NFT to. Double-check the recipient address to avoid sending your NFT to the wrong destination.
    :::note[Ronin Wallet app]
-   If you access Ronin Bridge through the Ronin Wallet mobile app, then you can enter any Ethereum address as a recipient, but only your imported Ethereum wallet can pay the gas fees for the transaction.
+   If you access Ronin Bridge through the Ronin Wallet mobile app, then you can enter any Ethereum address as a recipient, but only your imported Ethereum wallet can pay gas in ETH for the transaction.
    :::
    ![nft-withdrawal-3](../assets/nft-withdrawal-3.png)
 
@@ -38,11 +38,11 @@ To import your Ethereum wallets, see [Importing Your MetaMask Wallet to Ronin Wa
 
 ## Step 3. Approve the NFT
 
-To withdraw an NFT, you need to grant Ronin Bridge permission to transfer it, which is also referred to as *approval*. You have two ways to do it: approve a single token or approve all tokens.
+To withdraw an NFT, you need to grant Ronin Bridge permission to bridge it, which is also referred to as *approval*. You have two ways to do it: approve a single token or approve all tokens.
 
 ### Approve a single token
 
-Approving a single token means that every time you transfer an NFT, you will need to approve each token individually. So when you transfer another token in the future, you will need to approve it again.
+Approving a single token means that every time you bridge an NFT, you will need to approve each token individually. So when you bridge another token in the future, you will need to approve it again.
 
 1. With the NFT selected, click **Approve NFT**.
    ![nft-withdrawal-6](../assets/nft-withdrawal-6.png)
@@ -51,9 +51,9 @@ Approving a single token means that every time you transfer an NFT, you will nee
 
 ### Approve all tokens
 
-Approving all tokens means that you only need to grant approval once, and your future NFT transfers will not require any approval.
+Approving all tokens means that you only need to grant approval once, and your future NFT bridges will not require any approval.
 
-1. Select the NFT you want to transfer, then click **Approve NFT**.
+1. Select the NFT you want to bridge, then click **Approve NFT**.
    ![nft-withdrawal-6](../assets/nft-withdrawal-6.png)
 2. Select **All tokens**.
    ![nft-withdrawal-8](../assets/nft-withdrawal-8.png)
@@ -62,16 +62,16 @@ You can revoke token approval by using the [Token Revoke](https://ronin.axiedao.
 
 ## Step 4. Confirm your withdrawal
 
-1. Review the transaction details, including the gas fees associated with the withdrawal. Make sure you have enough ETH in your Ethereum wallet to cover the fees. If everything looks correct, select **Submit withdrawal**.
+1. Review the transaction details, including the gas associated with the withdrawal. Make sure you have enough ETH in your Ethereum wallet to pay gas. If everything looks correct, select **Submit withdrawal**.
    ![nft-withdrawal-9](../assets/nft-withdrawal-9.png)
 2. When prompted, sign the transaction in your Ronin Wallet.
 3. Select **Connect Wallet** and connect your Ethereum wallet.
    ![nft-withdrawal-10](../assets/nft-withdrawal-10.png)
 4. Wait for the transaction to be confirmed by the network. Be patient, however, as transactions can take some time to complete, depending on network congestion and gas fees.
    ![nft-withdrawal-11](../assets/nft-withdrawal-11.png)
-5. When the NFT is ready to be withdrawn, select **Withdraw** to transfer it to your Ethereum address.
+5. When the NFT is ready to be withdrawn, select **Withdraw** to bridge it to your Ethereum address.
    ![nft-withdrawal-12](../assets/nft-withdrawal-12.png)
-6. When prompted, sign the transaction in your connected Ethereum wallet to receive the transfer.
+6. When prompted, sign the transaction in your connected Ethereum wallet to receive the token.
 
 ## Step 5. Receive the NFT in your Ethereum wallet
 

--- a/docs/apps/ronin-bridge/guides/withdraw-token.md
+++ b/docs/apps/ronin-bridge/guides/withdraw-token.md
@@ -1,5 +1,5 @@
 ---
-description: Transfer ERC20 tokens from Ronin to Ethereum using Ronin Bridge.
+description: Bridge ERC20 tokens from Ronin to Ethereum using Ronin Bridge.
 slug: /apps/ronin-bridge/withdraw-token
 title: Withdraw an ERC20 token
 ---
@@ -22,9 +22,9 @@ To import your Ethereum wallets, see [Importing Your MetaMask Wallet to Ronin Wa
    ![token-withdrawal-1](../assets/token-withdrawal-1.png)
 3. In the **From** field, connect your Ronin Wallet using the browser extension or mobile app for your device.
    ![token-withdrawal-2](../assets/token-withdrawal-2.png)
-4. In the **To** field, enter the Ethereum address that you want to transfer the token to. Double-check the recipient address to avoid sending your tokens to the wrong destination.
+4. In the **To** field, enter the Ethereum address that you want to bridge the token to. Double-check the recipient address to avoid sending your tokens to the wrong destination.
    :::note[Ronin Wallet app]
-   If you access Ronin Bridge through the Ronin Wallet mobile app, then you can enter any Ethereum address as a recipient, but only your imported Ethereum wallet can pay the gas fees for the transaction.
+   If you access Ronin Bridge through the Ronin Wallet mobile app, then you can enter any Ethereum address as a recipient, but only your imported Ethereum wallet can pay gas in ETH for the transaction.
    :::
    ![token-withdrawal-3](../assets/token-withdrawal-3.png)
 
@@ -34,7 +34,7 @@ To import your Ethereum wallets, see [Importing Your MetaMask Wallet to Ronin Wa
    ![token-withdrawal-4](../assets/token-withdrawal-4.png)
 2. When prompted, select **Approve** to approve the new spending cap for the selected token.
    :::note[Spending cap]
-   When you transfer an ERC20 token for the first time, you need to set a spending cap. To do that, enter your desired transfer amount, then follow instructions on the screen to approve the cap. When you make another transfer with the amount that exceeds your current cap, you will need to approve a new spending cap corresponding to the higher amount.
+   When you bridge an ERC20 token for the first time, you need to set a spending cap. To do that, enter your desired token amount, then follow instructions on the screen to approve the cap. In the future, when you bridge an amount that exceeds your current cap, you will need to approve a new spending cap corresponding to the higher amount.
    :::
    ![token-withdrawal-5](../assets/token-withdrawal-5.png)
 3. When prompted, sign the transaction in your Ronin Wallet.
@@ -48,9 +48,9 @@ To import your Ethereum wallets, see [Importing Your MetaMask Wallet to Ronin Wa
    ![token-withdrawal-7](../assets/token-withdrawal-7.png)
 4. Wait for the transaction to be confirmed by the network. Be patient, however, as transactions can take some time to complete, depending on network congestion and gas fees.
    ![token-withdrawal-8](../assets/token-withdrawal-8.png)
-5. When the amount is ready to be withdrawn, select **Withdraw** to transfer the tokens to your Ethereum address.
+5. When the amount is ready to be withdrawn, select **Withdraw** to bridge the tokens to your Ethereum address.
    ![token-withdrawal-9](../assets/token-withdrawal-9.png)
-6. When prompted, sign the transaction in your connected Ethereum wallet to receive the transfer.
+6. When prompted, sign the transaction in your connected Ethereum wallet to receive the tokens.
 
 ## Step 4. Receive the tokens in your Ethereum wallet
 

--- a/docs/apps/ronin-bridge/overview.md
+++ b/docs/apps/ronin-bridge/overview.md
@@ -32,7 +32,7 @@ Ronin Bridge supports the following wallets:
 
 ### ERC20 tokens
 
-With Ronin Bridge, you can transfer the following ERC20 tokens:
+With Ronin Bridge, you can bridge the following ERC20 tokens:
 
 * Deposit: ETH, AXS, SLP, USDC, AGG, PIXEL, BANANA, AEC
 * Withdrawal: WETH, AXS, SLP, USDC, AGG, PIXEL, BANANA

--- a/docs/apps/ronin-bridge/reference/withdrawal-limits.md
+++ b/docs/apps/ronin-bridge/reference/withdrawal-limits.md
@@ -17,4 +17,6 @@ Withdrawing funds with Ronin Bridge has different tiers based on the amount and 
 | **PIXEL** | Capped at 300,000,000 | < 100,000,000 | ≥ 100,000,000 | ≥ 400,000,000 |
 | **BANANA** | Capped at 500,000 | < 100,000 | ≥ 100,000 | ≥ 600,000 |
 
-**Note:** Higher amounts (Tier 3) require manual review for security and have a fee of around 0.001% of the transaction value. These transactions aren't counted toward the daily limit per token.
+:::note
+Higher amounts (Tier 3) require manual review for security and have a fee of around 0.001% of the transaction value. These transactions aren't counted toward the daily limit per token.
+:::


### PR DESCRIPTION
### Reason

Closes: N/A

### What's being changed

Replaces the verb "transfer" with the verb "bridge" in Ronin Bridge documentation.

### Checklist

- [x] I've reviewed my changes in a preview environment (click the link in the "Preview" column to view your latest changes).
- [x] For content changes, I've completed the [self-review checklist](https://github.com/axieinfinity/ronin-documentation/blob/main/docs/CONTRIBUTING.md#self-review-checklist).
